### PR TITLE
feat: add WebSocket and GraphQl subscription

### DIFF
--- a/devtools/commands/devRuner/index.js
+++ b/devtools/commands/devRuner/index.js
@@ -1,3 +1,4 @@
+const http = require('http');
 const path = require('path');
 const chalk = require('chalk');
 const express = require('express');
@@ -170,7 +171,14 @@ class MainRunner {
             }
         });
 
-        app.listen(this.port);
+        // create the http server
+        const httpServer = http.createServer(app);
+
+        httpServer.on('upgrade', async (req, socket, head) => {
+            proxy.ws(req, socket, head, { target: await this.serverRunner.getUrl() });
+        });
+
+        httpServer.listen(this.port);
     }
 }
 

--- a/docs/async-worker.md
+++ b/docs/async-worker.md
@@ -60,10 +60,22 @@ const setup = (): (() => Promise<void>) => {
     const queues: QueueHandler[] = [
         // your new queue here
         dummyQueue.setupWorker(),
-    ];
 
-    // then schedule periodic jobs if you need to
-    dummyQueue.add({ value: 'whatever' }, { repeat: { cron: '10 * * * *' } });
+        // or if you want to plannify period job
+        // you may provide the list to schedule as follow :
+        dummyQueue.setupWorker([
+            {
+                // the job data
+                message: { value: 'whatever' },
+                // and the repeat definition as BullJS expects it
+                repeat: { cron: '10 * * * *' },
+            },
+        ]),
+
+        // if you want to manually handle the periodic jobs rather than relying on the homemade scheduler
+        // simply provide false instead
+        dummyQueue.setupWorker(false),
+    ];
 
     return async () => {
         // close queues

--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
         "express": "^4.17.1",
         "extract-files": "^9.0.0",
         "graphql": "^15.5.0",
+        "graphql-redis-subscriptions": "^2.3.1",
         "graphql-tools": "^7.0.4",
         "graphql-upload": "^11.0.0",
         "i18next": "^19.8.9",
@@ -178,6 +179,7 @@
         "react-router": "^5.2.0",
         "react-router-dom": "^5.2.0",
         "styled-components": "^5.2.1",
+        "subscriptions-transport-ws": "^0.9.18",
         "zxcvbn": "^4.4.2"
     }
 }

--- a/schema/Subscription.graphql
+++ b/schema/Subscription.graphql
@@ -1,0 +1,3 @@
+type Subscription {
+    topicUpdated(topicId: ObjectID!): Topic!
+}

--- a/schema/schema.graphql
+++ b/schema/schema.graphql
@@ -1,4 +1,5 @@
 schema {
     query: Query
     mutation: Mutation
+    subscription: Subscription
 }

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -1,7 +1,7 @@
 import { i18n as I18n } from 'i18next';
 import { I18nextProvider } from 'react-i18next';
 import { ThemeProvider } from 'styled-components';
-import Bootstrap from './Bootstrap';
+import Bootstrap, { BootstrapProps } from './Bootstrap';
 import MainRouter from './MainRouter';
 import { RuntimeProvider, RuntimeConfig } from './runtimeConfig';
 import theme from './theme';
@@ -9,13 +9,14 @@ import theme from './theme';
 export type AppProps = {
     i18n: I18n;
     runtime: RuntimeConfig;
+    createApolloClient: BootstrapProps['createApolloClient'];
 };
 
-const App = ({ i18n, runtime }: AppProps) => (
+const App = ({ i18n, runtime, createApolloClient }: AppProps) => (
     <RuntimeProvider runtime={runtime}>
         <I18nextProvider i18n={i18n}>
             <ThemeProvider theme={theme}>
-                <Bootstrap>
+                <Bootstrap createApolloClient={createApolloClient}>
                     <MainRouter />
                 </Bootstrap>
             </ThemeProvider>

--- a/src/app/Bootstrap.tsx
+++ b/src/app/Bootstrap.tsx
@@ -1,12 +1,12 @@
-import { from, ApolloClient, ApolloProvider, InMemoryCache, ApolloLink, NormalizedCacheObject } from '@apollo/client';
-import { BatchHttpLink } from 'apollo-link-batch-http';
-import { createUploadLink } from 'apollo-upload-client';
-import { extractFiles } from 'extract-files';
-import { i18n } from 'i18next';
+import { ApolloClient, ApolloProvider, NormalizedCacheObject } from '@apollo/client';
+import { i18n as I18n } from 'i18next';
 import { Component, ReactElement } from 'react';
 import { I18nContext } from 'react-i18next';
 
+export type ContextGetter = () => { i18n: I18n; token: string | undefined };
+
 export type BootstrapProps = {
+    createApolloClient: (getContext: ContextGetter) => ApolloClient<NormalizedCacheObject>;
     children: ReactElement;
 };
 
@@ -14,44 +14,19 @@ class Bootstrap extends Component<BootstrapProps> {
     private apolloClient: ApolloClient<NormalizedCacheObject>;
 
     // eslint-disable-next-line react/static-property-placement
-    public context: { i18n: i18n };
+    public context: { i18n: I18n };
 
-    constructor(props) {
+    constructor(props: BootstrapProps) {
         super(props);
 
-        // push the JWT token in headers
-        const authLink = new ApolloLink((operation, forward) => {
-            operation.setContext(({ headers }) => {
-                const { i18n } = this.context;
-                const customHeaders = { ...headers, 'Accept-Language': i18n.language };
-                const token = typeof window !== 'undefined' ? localStorage.getItem('jwt') : null;
+        const getContext = () => {
+            const { i18n } = this.context;
+            const token = typeof window !== 'undefined' ? localStorage.getItem('jwt') : undefined;
 
-                if (token) {
-                    customHeaders.Authorization = `Bearer ${token}`;
-                }
+            return { i18n, token };
+        };
 
-                return {
-                    headers: customHeaders,
-                };
-            });
-
-            return forward(operation);
-        });
-
-        // if there's file we are going to use the upload link
-        // otherwise use the batch http link
-        const httpLink = ApolloLink.split(
-            operation => extractFiles(operation).files.size > 0,
-            createUploadLink({ uri: '/graphql' }),
-            // @ts-ignore
-            new BatchHttpLink({ uri: '/graphql' })
-        );
-
-        this.apolloClient = new ApolloClient({
-            ssrMode: !process.browser,
-            link: from([authLink, httpLink]),
-            cache: new InMemoryCache(),
-        });
+        this.apolloClient = props.createApolloClient(getContext);
     }
 
     render() {

--- a/src/app/api/index.ts
+++ b/src/app/api/index.ts
@@ -6,6 +6,7 @@ export type Maybe<T> = T | null;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };
 export type MakeOptional<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]?: Maybe<T[SubKey]> };
 export type MakeMaybe<T, K extends keyof T> = Omit<T, K> & { [SubKey in K]: Maybe<T[SubKey]> };
+const defaultOptions = {};
 /** All built-in and custom scalars, mapped to their actual values */
 export type Scalars = {
     ID: string;
@@ -96,6 +97,15 @@ export type QueryTopicsArgs = {
 
 export type QueryTopicArgs = {
     id: Scalars['ObjectID'];
+};
+
+export type Subscription = {
+    __typename?: 'Subscription';
+    topicUpdated: Topic;
+};
+
+export type SubscriptionTopicUpdatedArgs = {
+    topicId: Scalars['ObjectID'];
 };
 
 export type Pagination = {
@@ -218,6 +228,15 @@ export type PostMessageMutationVariables = Exact<{
 export type PostMessageMutation = {
     __typename?: 'Mutation';
     postMessage: { __typename?: 'Topic' } & TopicFullDataFragment;
+};
+
+export type OnTopicUpdatesSubscriptionVariables = Exact<{
+    topicId: Scalars['ObjectID'];
+}>;
+
+export type OnTopicUpdatesSubscription = {
+    __typename?: 'Subscription';
+    topicUpdated: { __typename?: 'Topic'; id?: Maybe<string> };
 };
 
 export type UserPreviewDataFragment = { __typename?: 'User'; id: string; displayName: string };
@@ -515,12 +534,16 @@ export const GetTopicsDocument: DocumentNode = /* #__PURE__ */ {
  * });
  */
 export function useGetTopicsQuery(baseOptions?: Apollo.QueryHookOptions<GetTopicsQuery, GetTopicsQueryVariables>) {
-    return Apollo.useQuery<GetTopicsQuery, GetTopicsQueryVariables>(GetTopicsDocument, baseOptions);
+    const options = { ...defaultOptions, ...baseOptions };
+
+    return Apollo.useQuery<GetTopicsQuery, GetTopicsQueryVariables>(GetTopicsDocument, options);
 }
 export function useGetTopicsLazyQuery(
     baseOptions?: Apollo.LazyQueryHookOptions<GetTopicsQuery, GetTopicsQueryVariables>
 ) {
-    return Apollo.useLazyQuery<GetTopicsQuery, GetTopicsQueryVariables>(GetTopicsDocument, baseOptions);
+    const options = { ...defaultOptions, ...baseOptions };
+
+    return Apollo.useLazyQuery<GetTopicsQuery, GetTopicsQueryVariables>(GetTopicsDocument, options);
 }
 export type GetTopicsQueryHookResult = ReturnType<typeof useGetTopicsQuery>;
 export type GetTopicsLazyQueryHookResult = ReturnType<typeof useGetTopicsLazyQuery>;
@@ -644,10 +667,14 @@ export const GetTopicDocument: DocumentNode = /* #__PURE__ */ {
  * });
  */
 export function useGetTopicQuery(baseOptions: Apollo.QueryHookOptions<GetTopicQuery, GetTopicQueryVariables>) {
-    return Apollo.useQuery<GetTopicQuery, GetTopicQueryVariables>(GetTopicDocument, baseOptions);
+    const options = { ...defaultOptions, ...baseOptions };
+
+    return Apollo.useQuery<GetTopicQuery, GetTopicQueryVariables>(GetTopicDocument, options);
 }
 export function useGetTopicLazyQuery(baseOptions?: Apollo.LazyQueryHookOptions<GetTopicQuery, GetTopicQueryVariables>) {
-    return Apollo.useLazyQuery<GetTopicQuery, GetTopicQueryVariables>(GetTopicDocument, baseOptions);
+    const options = { ...defaultOptions, ...baseOptions };
+
+    return Apollo.useLazyQuery<GetTopicQuery, GetTopicQueryVariables>(GetTopicDocument, options);
 }
 export type GetTopicQueryHookResult = ReturnType<typeof useGetTopicQuery>;
 export type GetTopicLazyQueryHookResult = ReturnType<typeof useGetTopicLazyQuery>;
@@ -783,7 +810,9 @@ export type CreateTopicMutationFn = Apollo.MutationFunction<CreateTopicMutation,
 export function useCreateTopicMutation(
     baseOptions?: Apollo.MutationHookOptions<CreateTopicMutation, CreateTopicMutationVariables>
 ) {
-    return Apollo.useMutation<CreateTopicMutation, CreateTopicMutationVariables>(CreateTopicDocument, baseOptions);
+    const options = { ...defaultOptions, ...baseOptions };
+
+    return Apollo.useMutation<CreateTopicMutation, CreateTopicMutationVariables>(CreateTopicDocument, options);
 }
 export type CreateTopicMutationHookResult = ReturnType<typeof useCreateTopicMutation>;
 export type CreateTopicMutationResult = Apollo.MutationResult<CreateTopicMutation>;
@@ -922,11 +951,82 @@ export type PostMessageMutationFn = Apollo.MutationFunction<PostMessageMutation,
 export function usePostMessageMutation(
     baseOptions?: Apollo.MutationHookOptions<PostMessageMutation, PostMessageMutationVariables>
 ) {
-    return Apollo.useMutation<PostMessageMutation, PostMessageMutationVariables>(PostMessageDocument, baseOptions);
+    const options = { ...defaultOptions, ...baseOptions };
+
+    return Apollo.useMutation<PostMessageMutation, PostMessageMutationVariables>(PostMessageDocument, options);
 }
 export type PostMessageMutationHookResult = ReturnType<typeof usePostMessageMutation>;
 export type PostMessageMutationResult = Apollo.MutationResult<PostMessageMutation>;
 export type PostMessageMutationOptions = Apollo.BaseMutationOptions<PostMessageMutation, PostMessageMutationVariables>;
+export const OnTopicUpdatesDocument: DocumentNode = /* #__PURE__ */ {
+    kind: 'Document',
+    definitions: [
+        {
+            kind: 'OperationDefinition',
+            operation: 'subscription',
+            name: { kind: 'Name', value: 'onTopicUpdates' },
+            variableDefinitions: [
+                {
+                    kind: 'VariableDefinition',
+                    variable: { kind: 'Variable', name: { kind: 'Name', value: 'topicId' } },
+                    type: {
+                        kind: 'NonNullType',
+                        type: { kind: 'NamedType', name: { kind: 'Name', value: 'ObjectID' } },
+                    },
+                },
+            ],
+            selectionSet: {
+                kind: 'SelectionSet',
+                selections: [
+                    {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'topicUpdated' },
+                        arguments: [
+                            {
+                                kind: 'Argument',
+                                name: { kind: 'Name', value: 'topicId' },
+                                value: { kind: 'Variable', name: { kind: 'Name', value: 'topicId' } },
+                            },
+                        ],
+                        selectionSet: {
+                            kind: 'SelectionSet',
+                            selections: [{ kind: 'Field', name: { kind: 'Name', value: 'id' } }],
+                        },
+                    },
+                ],
+            },
+        },
+    ],
+};
+
+/**
+ * __useOnTopicUpdatesSubscription__
+ *
+ * To run a query within a React component, call `useOnTopicUpdatesSubscription` and pass it any options that fit your needs.
+ * When your component renders, `useOnTopicUpdatesSubscription` returns an object from Apollo Client that contains loading, error, and data properties
+ * you can use to render your UI.
+ *
+ * @param baseOptions options that will be passed into the subscription, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options;
+ *
+ * @example
+ * const { data, loading, error } = useOnTopicUpdatesSubscription({
+ *   variables: {
+ *      topicId: // value for 'topicId'
+ *   },
+ * });
+ */
+export function useOnTopicUpdatesSubscription(
+    baseOptions: Apollo.SubscriptionHookOptions<OnTopicUpdatesSubscription, OnTopicUpdatesSubscriptionVariables>
+) {
+    const options = { ...defaultOptions, ...baseOptions };
+
+    return Apollo.useSubscription<OnTopicUpdatesSubscription, OnTopicUpdatesSubscriptionVariables>(
+        OnTopicUpdatesDocument,
+        options
+    );
+}
+export type OnTopicUpdatesSubscriptionHookResult = ReturnType<typeof useOnTopicUpdatesSubscription>;
+export type OnTopicUpdatesSubscriptionResult = Apollo.SubscriptionResult<OnTopicUpdatesSubscription>;
 export const CreateNewAccountDocument: DocumentNode = /* #__PURE__ */ {
     kind: 'Document',
     definitions: [
@@ -1000,9 +1100,11 @@ export type CreateNewAccountMutationFn = Apollo.MutationFunction<
 export function useCreateNewAccountMutation(
     baseOptions?: Apollo.MutationHookOptions<CreateNewAccountMutation, CreateNewAccountMutationVariables>
 ) {
+    const options = { ...defaultOptions, ...baseOptions };
+
     return Apollo.useMutation<CreateNewAccountMutation, CreateNewAccountMutationVariables>(
         CreateNewAccountDocument,
-        baseOptions
+        options
     );
 }
 export type CreateNewAccountMutationHookResult = ReturnType<typeof useCreateNewAccountMutation>;
@@ -1076,9 +1178,11 @@ export type UpdateDisplayNameMutationFn = Apollo.MutationFunction<
 export function useUpdateDisplayNameMutation(
     baseOptions?: Apollo.MutationHookOptions<UpdateDisplayNameMutation, UpdateDisplayNameMutationVariables>
 ) {
+    const options = { ...defaultOptions, ...baseOptions };
+
     return Apollo.useMutation<UpdateDisplayNameMutation, UpdateDisplayNameMutationVariables>(
         UpdateDisplayNameDocument,
-        baseOptions
+        options
     );
 }
 export type UpdateDisplayNameMutationHookResult = ReturnType<typeof useUpdateDisplayNameMutation>;

--- a/src/app/api/topic.graphql
+++ b/src/app/api/topic.graphql
@@ -23,3 +23,9 @@ mutation postMessage($topicId: ObjectID!, $body: String!) {
         ...TopicFullData
     }
 }
+
+subscription onTopicUpdates($topicId: ObjectID!) {
+    topicUpdated(topicId: $topicId) {
+        id
+    }
+}

--- a/src/app/createApolloClient.ts
+++ b/src/app/createApolloClient.ts
@@ -1,0 +1,75 @@
+import { ApolloClient, ApolloLink, from, InMemoryCache, NormalizedCacheObject } from '@apollo/client';
+import { WebSocketLink } from '@apollo/client/link/ws';
+import { getMainDefinition } from '@apollo/client/utilities';
+import { BatchHttpLink } from 'apollo-link-batch-http';
+import { createUploadLink } from 'apollo-upload-client';
+import { extractFiles } from 'extract-files';
+import { i18n as I18n } from 'i18next';
+
+const createApolloClient = (
+    getContext: () => { i18n: I18n; token: string | undefined }
+): ApolloClient<NormalizedCacheObject> => {
+    // push the JWT token in headers
+    const authLink = new ApolloLink((operation, forward) => {
+        operation.setContext(({ headers }) => {
+            const { i18n, token } = getContext();
+            const customHeaders = { ...headers, 'Accept-Language': i18n.language };
+
+            if (token) {
+                customHeaders.Authorization = `Bearer ${token}`;
+            }
+
+            return {
+                headers: customHeaders,
+            };
+        });
+
+        return forward(operation);
+    });
+
+    // if there's file we are going to use the upload link
+    // otherwise use the batch http link
+    const httpLink = ApolloLink.split(
+        operation => extractFiles(operation).files.size > 0,
+        createUploadLink({ uri: '/graphql' }),
+        // @ts-ignore
+        new BatchHttpLink({ uri: '/graphql' })
+    );
+
+    // websocket link
+    const wsLink = new WebSocketLink({
+        uri: `ws://${window.location.host}/graphql`,
+        options: {
+            reconnect: true,
+            lazy: true,
+            connectionParams: () => {
+                const token = typeof window !== 'undefined' ? localStorage.getItem('jwt') : null;
+
+                if (token) {
+                    return { authToken: token };
+                }
+
+                return {};
+            },
+        },
+    });
+
+    // split between HTTP and WS protocols
+    const rootLink = ApolloLink.split(
+        ({ query }) => {
+            const definition = getMainDefinition(query);
+
+            return definition.kind === 'OperationDefinition' && definition.operation === 'subscription';
+        },
+        wsLink,
+        from([authLink, httpLink])
+    );
+
+    return new ApolloClient({
+        ssrMode: false,
+        link: rootLink,
+        cache: new InMemoryCache(),
+    });
+};
+
+export default createApolloClient;

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -4,6 +4,7 @@ import { hydrate } from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
 import createI18Instance from '../shared/createI18nInstance/browser';
 import App from './App';
+import createApolloClient from './createApolloClient';
 import { RuntimeConfig } from './runtimeConfig';
 
 const runtimeConfig = JSON.parse(
@@ -36,7 +37,7 @@ if (runtimeConfig.sentry.dsn) {
 
 const element = (
     <BrowserRouter>
-        <App i18n={i18n} runtime={runtimeConfig} />
+        <App createApolloClient={createApolloClient} i18n={i18n} runtime={runtimeConfig} />
     </BrowserRouter>
 );
 

--- a/src/server/createApolloClient.ts
+++ b/src/server/createApolloClient.ts
@@ -1,0 +1,17 @@
+import { ApolloClient, InMemoryCache, NormalizedCacheObject } from '@apollo/client';
+import { SchemaLink } from '@apollo/client/link/schema';
+import schema from './schema';
+import { Context } from './schema/context';
+
+const createApolloClient = (context: Context) => (): ApolloClient<NormalizedCacheObject> => {
+    // create a schema link
+    const schemaLink = new SchemaLink({ schema, rootValue: null, context });
+
+    return new ApolloClient({
+        ssrMode: true,
+        link: schemaLink,
+        cache: new InMemoryCache(),
+    });
+};
+
+export default createApolloClient;

--- a/src/server/global.d.ts
+++ b/src/server/global.d.ts
@@ -1,3 +1,4 @@
+import { RedisPubSub } from 'graphql-redis-subscriptions';
 import { Redis } from 'ioredis';
 import { MongoClient, Db } from 'mongodb';
 
@@ -9,6 +10,7 @@ declare global {
                 promise: Promise<{ mongoClient: MongoClient; db: Db }>;
             };
             redis?: Redis;
+            pubSub?: RedisPubSub;
         }
     }
 }

--- a/src/server/pubSub.ts
+++ b/src/server/pubSub.ts
@@ -1,0 +1,50 @@
+import { EJSON, Document } from 'bson';
+import { RedisPubSub } from 'graphql-redis-subscriptions';
+import IORedis from 'ioredis';
+import config from './config';
+
+export const getPubSub = (): RedisPubSub => {
+    if (global.pubSub) {
+        return global.pubSub;
+    }
+
+    global.pubSub = new RedisPubSub({
+        publisher: new IORedis(config.redis.uri, { enableOfflineQueue: false }),
+        subscriber: new IORedis(config.redis.uri, { enableOfflineQueue: false }),
+        serializer: (source: Document): string => JSON.stringify(EJSON.serialize(source)),
+        deserializer: (source: string): Document => EJSON.deserialize(JSON.parse(source)) as Document,
+    });
+
+    return global.pubSub;
+};
+
+export type SubscriptionTriggerGenerators<TMessage, TSubArgs extends any[]> = {
+    fromMessage: (message: TMessage) => string;
+    fromArgs: (...args: TSubArgs) => string[];
+};
+
+export class Subscription<TMessage, TSubArgs extends any[] = []> {
+    private readonly trigger: SubscriptionTriggerGenerators<TMessage, TSubArgs>;
+
+    private readonly name: string;
+
+    constructor(trigger: string | SubscriptionTriggerGenerators<TMessage, TSubArgs>, name: string) {
+        this.trigger =
+            typeof trigger === 'string'
+                ? {
+                      fromMessage: () => trigger,
+                      fromArgs: () => [trigger],
+                  }
+                : trigger;
+
+        this.name = name;
+    }
+
+    public subscribe(...args: TSubArgs): AsyncIterator<any> {
+        return getPubSub().asyncIterator(this.trigger.fromArgs(...args));
+    }
+
+    public publish(message: TMessage): void {
+        getPubSub().publish(this.trigger.fromMessage(message), { [this.name]: message });
+    }
+}

--- a/src/server/queues/QueueHandler.ts
+++ b/src/server/queues/QueueHandler.ts
@@ -4,7 +4,23 @@ import BullQueue, { Queue, Job, JobOptions } from 'bull';
 import chalk from 'chalk';
 import config from '../config';
 
+/* comes from BullJS
+ * https://github.com/OptimalBits/bull/blob/46fcba14bc01885c1ca518b3399ec474bb88b71d/lib/repeatable.js#L177
+ * */
+const getRepeatKey = (repeat: JobOptions['repeat']): string => {
+    // @ts-ignore
+    const jobId = repeat.jobId ? `${repeat.jobId}:` : ':';
+    const endDate = repeat.endDate ? `${new Date(repeat.endDate).getTime()}:` : ':';
+    const tz = repeat.tz ? `${repeat.tz}:` : ':';
+    // @ts-ignore
+    const suffix = repeat.cron ? tz + repeat.cron : String(repeat.every);
+
+    return `__default__:${jobId}${endDate}${suffix}`;
+};
+
 export type ProcessFunction<Message> = (message: Message, job: Job<Document>) => Promise<void> | void;
+
+export type QueuePeriodicPlans<Message> = { message: Message; repeat: JobOptions['repeat'] };
 
 export class QueueHandler<Message = any> {
     public readonly queueName;
@@ -25,42 +41,75 @@ export class QueueHandler<Message = any> {
         return this.queue.add(serializedMessage, options);
     }
 
-    public setupWorker(): QueueHandler<Message> {
-        this.queue.process(async job => {
-            const transaction = Sentry.startTransaction({
-                op: 'task',
-                name: this.queueName,
+    private async setupPeriodicPlan(plans: QueuePeriodicPlans<Message>[] = []) {
+        const jobs = await this.queue.getRepeatableJobs();
+
+        const existingKeys = plans
+            .map(plan => {
+                // get the repeat job key
+                const repeatJobKey = getRepeatKey(plan.repeat);
+
+                // look for a match
+                const matchingJob = jobs.find(job => job.key === repeatJobKey);
+
+                if (!matchingJob) {
+                    // add a new job
+                    this.add(plan.message, { repeat: plan.repeat });
+                }
+
+                return matchingJob ? repeatJobKey : undefined;
+            })
+            .filter(Boolean);
+
+        // remove outdated job
+        jobs.filter(job => !existingKeys.includes(job.key)).forEach(job => {
+            this.queue.removeRepeatableByKey(job.key);
+        });
+    }
+
+    private async handleJob(job: Job<Document>) {
+        const transaction = Sentry.startTransaction({
+            op: 'task',
+            name: this.queueName,
+        });
+
+        let message: Message = null;
+
+        try {
+            message = EJSON.deserialize(job.data) as Message;
+
+            const promise = this.processFunction(message, job);
+
+            if (promise instanceof Promise) {
+                await promise;
+            }
+        } catch (error) {
+            // print it for debug purposes
+            console.info(chalk.red(`Failed to execute ${this.queueName}`));
+            console.error(error);
+
+            Sentry.withScope(scope => {
+                if (message) {
+                    scope.setExtra('message', message);
+                }
+
+                Sentry.captureException(error);
             });
 
-            let message: Message = null;
+            // set the job as failed
+            await job.moveToFailed(error);
+        } finally {
+            transaction.finish();
+        }
+    }
 
-            try {
-                message = EJSON.deserialize(job.data) as Message;
+    public setupWorker(plans?: QueuePeriodicPlans<Message>[] | false): QueueHandler<Message> {
+        this.queue.process(this.handleJob.bind(this));
 
-                const promise = this.processFunction(message, job);
-
-                if (promise instanceof Promise) {
-                    await promise;
-                }
-            } catch (error) {
-                // print it for debug purposes
-                console.info(chalk.red(`Failed to execute ${this.queueName}`));
-                console.error(error);
-
-                Sentry.withScope(scope => {
-                    if (message) {
-                        scope.setExtra('message', message);
-                    }
-
-                    Sentry.captureException(error);
-                });
-
-                // set the job as failed
-                await job.moveToFailed(error);
-            } finally {
-                transaction.finish();
-            }
-        });
+        if (plans !== false) {
+            // we managed the periodic tasks
+            this.setupPeriodicPlan(plans);
+        }
 
         return this;
     }

--- a/src/server/queues/setup.ts
+++ b/src/server/queues/setup.ts
@@ -3,10 +3,15 @@ import { dummyQueue } from './dummyQueue';
 
 const setup = (): (() => Promise<void>) => {
     // first initialize every queues
-    const queues: QueueHandler[] = [dummyQueue.setupWorker()];
-
-    // then schedule periodic jobs
-    // dummyQueue.add({ value: 'periodic' }, { repeat: { cron: '10 * * * *' } });
+    const queues: QueueHandler[] = [
+        dummyQueue.setupWorker([
+            // provide a periodic plan to send an email every hour
+            {
+                message: { value: 'periodic' },
+                repeat: { cron: '0 * * * *' },
+            },
+        ]),
+    ];
 
     return async () => {
         // close queues

--- a/src/server/schema/resolvers/index.ts
+++ b/src/server/schema/resolvers/index.ts
@@ -1,11 +1,13 @@
 import * as enums from './enums';
 import * as Mutation from './mutations';
 import * as Query from './queries';
+import * as Subscription from './subscriptions';
 import * as types from './types';
 
 const resolvers = {
     Query,
     Mutation,
+    Subscription,
     ...types,
     ...enums,
 };

--- a/src/server/schema/resolvers/mutations/postMessage.ts
+++ b/src/server/schema/resolvers/mutations/postMessage.ts
@@ -2,6 +2,7 @@ import { ObjectId } from 'mongodb';
 import { getDatabaseContext, TopicMessage, Topic } from '../../../database';
 import { RootResolver } from '../../context';
 import { requiresLoggedUser } from '../../middlewares';
+import { topicUpdatedSubscription } from '../subscriptions/topicUpdated';
 
 type Args = { topicId: ObjectId; body: string };
 
@@ -23,6 +24,11 @@ const mutation: RootResolver<Args> = async (root, { topicId, body }, { getUser }
         { $push: { messages: document }, $set: { updatedAt: now } },
         { returnOriginal: false }
     );
+
+    if (operation.value) {
+        // emit on the subscription this topic has been updated
+        topicUpdatedSubscription.publish(operation.value);
+    }
 
     return operation?.value;
 };

--- a/src/server/schema/resolvers/subscriptions/index.ts
+++ b/src/server/schema/resolvers/subscriptions/index.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line import/prefer-default-export
+export { default as topicUpdated } from './topicUpdated';

--- a/src/server/schema/resolvers/subscriptions/topicUpdated.ts
+++ b/src/server/schema/resolvers/subscriptions/topicUpdated.ts
@@ -1,0 +1,25 @@
+import { withFilter } from 'apollo-server';
+import { ObjectId } from 'mongodb';
+import { Topic } from '../../../database';
+import { Subscription } from '../../../pubSub';
+
+type Args = {
+    topicId: ObjectId;
+};
+
+export type TopicUpdatedMessage = Topic;
+
+type Payload = { topicUpdated: TopicUpdatedMessage };
+
+export const topicUpdatedSubscription = new Subscription<TopicUpdatedMessage>('gql.topicUpdated', 'topicUpdated');
+
+const resolver = {
+    subscribe: withFilter(
+        () => topicUpdatedSubscription.subscribe(),
+        (payload: Payload, variables: Args) =>
+            // only push for the same topic
+            payload.topicUpdated._id.equals(variables.topicId)
+    ),
+};
+
+export default resolver;

--- a/src/server/schema/session.ts
+++ b/src/server/schema/session.ts
@@ -1,6 +1,6 @@
+import { IncomingMessage } from 'http';
 import { AuthenticationError } from 'apollo-server';
 import { EJSON, Document } from 'bson';
-import { Request } from 'express';
 import jwt from 'jsonwebtoken';
 import { omit } from 'lodash/fp';
 import { ObjectId } from 'mongodb';
@@ -23,7 +23,7 @@ export const readSessionToken = async (token: string): Promise<SessionData> => {
     return omit(['iat', 'exp'], data);
 };
 
-export const getSessionDataFromRequest = async (req: Request): Promise<SessionData | null> => {
+export const getSessionDataFromRequest = async (req: IncomingMessage): Promise<SessionData | null> => {
     const header = req.headers?.authorization as string;
 
     if (!header) {

--- a/src/server/schema/typeDefs.graphql
+++ b/src/server/schema/typeDefs.graphql
@@ -1,6 +1,7 @@
 schema {
     query: Query
     mutation: Mutation
+    subscription: Subscription
 }
 type Mutation {
     """
@@ -51,6 +52,9 @@ type Query {
     Fetch user document for the logged in user, returns null otherwise for anonymous
     """
     account: User
+}
+type Subscription {
+    topicUpdated(topicId: ObjectID!): Topic!
 }
 scalar ObjectID
 scalar DateTime

--- a/src/shared/createI18nInstance/defaultConfig.ts
+++ b/src/shared/createI18nInstance/defaultConfig.ts
@@ -2,6 +2,7 @@ import { InitOptions } from 'i18next';
 
 const defaultConfig: InitOptions = {
     defaultNS: 'common',
+    ns: [],
 
     interpolation: {
         escapeValue: false,

--- a/yarn.lock
+++ b/yarn.lock
@@ -6476,6 +6476,15 @@ graphql-extensions@^0.12.8:
     apollo-server-env "^3.0.0"
     apollo-server-types "^0.6.3"
 
+graphql-redis-subscriptions@^2.3.1:
+  version "2.3.1"
+  resolved "https://registry.yarnpkg.com/graphql-redis-subscriptions/-/graphql-redis-subscriptions-2.3.1.tgz#53d67d157f9c8c48ef0c5c1902f42fe2d0b93e27"
+  integrity sha512-ztS3ZXBSoPJ8Q0/o7PG2iLO6QWq2tlJrukiBJCjgMccRv1I3lt3HmLjiH2CbDjPhpoINttZNoytQbxE0OE/UpA==
+  dependencies:
+    iterall "^1.3.0"
+  optionalDependencies:
+    ioredis "^4.17.3"
+
 graphql-request@^3.3.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/graphql-request/-/graphql-request-3.4.0.tgz#3a400cd5511eb3c064b1873afb059196bbea9c2b"
@@ -7026,7 +7035,7 @@ internal-slot@^1.0.3:
     has "^1.0.3"
     side-channel "^1.0.4"
 
-ioredis@^4.22.0:
+ioredis@^4.17.3, ioredis@^4.22.0:
   version "4.23.0"
   resolved "https://registry.yarnpkg.com/ioredis/-/ioredis-4.23.0.tgz#f61b65633a25c93f43fccebcacac2f4342e418f9"
   integrity sha512-R5TDCODwnEH3J3A5TSoB17+6a+SeJTtIOW6vsy5Q1yag/AM8FejHjZC5R2O1QepSXV8hwOnGSm/4buJc/LeXTQ==
@@ -12086,7 +12095,7 @@ styled-components@^5.2.1:
     shallowequal "^1.1.0"
     supports-color "^5.5.0"
 
-subscriptions-transport-ws@^0.9.11, subscriptions-transport-ws@^0.9.16:
+subscriptions-transport-ws@^0.9.11, subscriptions-transport-ws@^0.9.16, subscriptions-transport-ws@^0.9.18:
   version "0.9.18"
   resolved "https://registry.yarnpkg.com/subscriptions-transport-ws/-/subscriptions-transport-ws-0.9.18.tgz#bcf02320c911fbadb054f7f928e51c6041a37b97"
   integrity sha512-tztzcBTNoEbuErsVQpTN2xUNN/efAZXyCyL5m3x4t6SKrEiTL2N8SaKWBFWM4u56pL79ULif3zjyeq+oV+nOaA==


### PR DESCRIPTION
* Add GraphQL subscription support on both BE and FE
* On SSR the apollo client will use instead schema link
* Refactor the periodic job scheduler inside the helper for BullJS to avoid having zombies jobs
* Update the dev server to use Node HTTP as base rather than express (required for HTTP upgrades for WebSockets)
* Update documentation and add a example on subscriptions

Close #17 