### PR TITLE
chore: disable CORS on development setup

### DIFF
--- a/src/server/core/createWebServer.ts
+++ b/src/server/core/createWebServer.ts
@@ -116,7 +116,7 @@ const createWebServer = async (): Promise<WebServerCreation> => {
             const scheme = req.header('X-Forwarded-Scheme') || 'https';
 
             // apply cors
-            callback(null, { origin: host ? `${scheme}://${host}` : false });
+            callback(null, { origin: !process.isDev && host ? `${scheme}://${host}` : false });
         })
     );
 


### PR DESCRIPTION
We need to disable CORS to allow developer to play with the API with tools such as Apollo Studio.
We could also add more domains to the CORS but we favor the most simple solution in this case.
Final security compliance once deployed in kubernetes cluster is not impacted by this change.
The development boolean is only defined by Webpack when running development builds.