### PR TITLE
feat: add worker beat and refactor jobs

### DIFF
--- a/charts/app/templates/configmap.yaml
+++ b/charts/app/templates/configmap.yaml
@@ -24,6 +24,7 @@ data:
   APP_HEALTH_ENABLED: "true"
   {{- include "app.configValue" ( dict "Key" "APP_HEALTH_PORT" "Value" .port ) }}
   {{- include "app.configValue" ( dict "Key" "APP_HEALTH_ALLOWED" "Value" .allowed ) }}
+  {{- include "app.configValue" ( dict "Key" "APP_HEALTH_WORKER_BEAT" "Value" .workerBeat ) }}
   {{- end }}
 
   # smtp settings

--- a/charts/app/values.yaml
+++ b/charts/app/values.yaml
@@ -62,6 +62,7 @@ app:
     health:
         port: 4000
         allowed: '0.0.0.0/0,::/0'
+        workerBeat: ''
 
     # database settings
     database:

--- a/docs/async-worker.md
+++ b/docs/async-worker.md
@@ -16,7 +16,7 @@ All jobs/workers are defined in the `src/server/queues` directory
 
 ## Example
 
-First create a file for your new job such as `dummyQueue.ts` in which you will have the following code
+First create a file for your new job such as `implementations/dummyQueue.ts` in which you will have the following code
 
 ```ts
 // we need the Document type from bson
@@ -30,61 +30,36 @@ import { QueueHandler } from './QueueHandler';
 export type DummyMessage = { value: string };
 
 // our handler to execute the code
-const handler = async (message: DummyMessage, job: Job<Document>) => {
+export const dummyJandler = async (message: DummyMessage, job: Job<Document>) => {
     // then here we do whatever we need to execute here
     // for example print the value
     console.info(message.value);
 };
-
-// create our queue instance
-// the name must be uniq (here it's "yummy")
-export const dummyQueue = new QueueHandler('dummy', handler);
 ```
 
-After what you may first export your queue types and instance from the queues entry points (`src/server/queues/index.ts`) :
+After what you may first export your queue types and instance from the implementation entry point (`src/server/queues/implementations/index.ts`) :
 
 ```ts
-// simply export everything here
+// add the following line to export everything fromt he file you just created
 export * from './dummyQueue';
-export { default as setup } from './setup';
 ```
 
-Finally, add your queue in the setup method (in `src/server/queues/setup.ts`)
+Then, if you want your job to be included in the main queue you should add it to the main handler (in `src/server/queues/mainQueue.ts`)
 
 ```ts
-import { QueueHandler } from './QueueHandler';
-import { dummyQueue } from './dummyQueue';
+// add it to the message types
+export type QueueMessage =
+    | ({ type: 'dummy' } & implementations.DummyMessage)
+    | ({ type: 'otherType' } & implementations.OtherTypeMessage);
 
-const setup = (): (() => Promise<void>) => {
-    // first initialize every queues
-    const queues: QueueHandler[] = [
-        // your new queue here
-        dummyQueue.setupWorker(),
+const mainQueueHandler = (message: QueueMessage, job: Job<Document>) => {
+    switch (message.type) {
+        /* .... */
 
-        // or if you want to plannify period job
-        // you may provide the list to schedule as follow :
-        dummyQueue.setupWorker([
-            {
-                // the job data
-                message: { value: 'whatever' },
-                // and the repeat definition as BullJS expects it
-                repeat: { cron: '10 * * * *' },
-            },
-        ]),
+        case 'dummy':
+            return implementations.dummyHandler(message, job);
 
-        // if you want to manually handle the periodic jobs rather than relying on the homemade scheduler
-        // simply provide false instead
-        dummyQueue.setupWorker(false),
-    ];
-
-    return async () => {
-        // close queues
-        await Promise.all(queues.map(queue => queue.stop()));
-    };
+        /* .... */
+    }
 };
-
-export default setup;
 ```
-
-If you remove a periodic queue you may need to remove the scheduler from data migration.
-To understand how please read the documentation on BullJS.

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -32,11 +32,12 @@ It's recommended to disable compression if you may delegate it to a reverse prox
 
 ## Health checks configuration
 
-| Name               | Type    | Default             | Comment                               |
-| ------------------ | ------- |---------------------|---------------------------------------|
-| APP_HEALTH_ENABLED | Boolean | false               | Serve health checks                   |
-| APP_HEALTH_PORT    | Number  | 4000                | Port on which serve the health checks |
-| APP_HEALTH_ALLOWED | String  | ::1/128,127.0.0.0/8 | Allowed CIDR for the health checks    |
+| Name                   | Type    | Default             | Comment                               |
+| ---------------------- | ------- | ------------------- | ------------------------------------- |
+| APP_HEALTH_ENABLED     | Boolean | false               | Serve health checks                   |
+| APP_HEALTH_PORT        | Number  | 4000                | Port on which serve the health checks |
+| APP_HEALTH_ALLOWED     | String  | ::1/128,127.0.0.0/8 | Allowed CIDR for the health checks    |
+| APP_HEALTH_WORKER_BEAT | String  |                     | URL for worker beat pushes            |
 
 ## Session configuration
 

--- a/package.json
+++ b/package.json
@@ -197,6 +197,7 @@
         "nodemailer": "^6.5.0",
         "prom-client": "^14.0.0",
         "pubsub-js": "^1.9.4",
+        "query-string": "^7.1.1",
         "rate-limiter-flexible": "^2.2.1",
         "react": "^17.0.1",
         "react-dom": "^17.0.1",

--- a/src/server/core/config.ts
+++ b/src/server/core/config.ts
@@ -48,6 +48,7 @@ const config = {
         enabled: getBoolean(getPrefix('HEALTH_ENABLED'), false),
         port: getNumber(getPrefix('HEALTH_PORT'), 4000),
         allowed: getStringList(getPrefix('HEALTH_ALLOWED'), ['::1/128', '127.0.0.0/8']),
+        workerBeat: getString(getPrefix('HEALTH_WORKER_BEAT')),
     },
 
     // gzip module

--- a/src/server/core/health.ts
+++ b/src/server/core/health.ts
@@ -3,7 +3,7 @@ import chalk from 'chalk';
 import express, { Router, RequestHandler } from 'express';
 import ipaddr from 'ipaddr.js';
 import { getDatabaseContext } from '../database';
-import * as queues from '../queues/implementations';
+import { queues } from '../queues/setup';
 import config from './config';
 import getRedisInstance from './redis';
 
@@ -14,7 +14,7 @@ export enum HealthStatus {
     Stopped,
 }
 
-const runHealthChecks = async () => {
+export const runHealthChecks = async () => {
     // check the main redis first
     await getRedisInstance().ping();
 

--- a/src/server/queues/implementations/dummy.ts
+++ b/src/server/queues/implementations/dummy.ts
@@ -1,16 +1,13 @@
 import { Document } from 'bson';
 import { Job } from 'bull';
 import { sendDummyEmail } from '../../emails';
-import { QueueHandler } from '../QueueHandler';
 
 export type DummyMessage = { value: string };
 
-const handler = async (message: DummyMessage, job: Job<Document>) => {
+export const dummyHandler = async (message: DummyMessage, job: Job<Document>) => {
     await sendDummyEmail({
         subject: 'test',
         to: 'noreply@appvantage.co',
         data: { text: message.value },
     });
 };
-
-export const dummyQueue = new QueueHandler('dummy', handler);

--- a/src/server/queues/implementations/index.ts
+++ b/src/server/queues/implementations/index.ts
@@ -1,1 +1,2 @@
-export { dummyQueue } from './dummyQueue';
+export * from './dummy';
+export * from './workerBeat';

--- a/src/server/queues/implementations/workerBeat.ts
+++ b/src/server/queues/implementations/workerBeat.ts
@@ -1,0 +1,29 @@
+import * as Sentry from '@sentry/node';
+import { Document } from 'bson';
+import { Job } from 'bull';
+import fetch from 'node-fetch';
+import queryString from 'query-string';
+import config from '../../core/config';
+import { runHealthChecks } from '../../core/health';
+
+export type WorkerBeatMessage = {};
+
+export const workerBeatHandler = async (message: WorkerBeatMessage, job: Job<Document>) => {
+    if (!config.healthChecks.workerBeat) {
+        // there's no beat to call
+        return;
+    }
+
+    const args = queryString.stringify({ msg: 'OK ' });
+
+    try {
+        // do health check first
+        await runHealthChecks();
+        // then call the beat
+        await fetch(`${config.healthChecks.workerBeat}?${args}`);
+    } catch (error) {
+        // print the error and log with Sentry
+        console.error(error);
+        Sentry.captureException(error);
+    }
+};

--- a/src/server/queues/index.ts
+++ b/src/server/queues/index.ts
@@ -1,3 +1,4 @@
 export * from './implementations';
+export * from './mainQueue';
 export { default as setup } from './setup';
 export { default as stopAllQueues } from './stopAllQueues';

--- a/src/server/queues/mainQueue.ts
+++ b/src/server/queues/mainQueue.ts
@@ -1,0 +1,24 @@
+import { Document } from 'bson';
+import { Job } from 'bull';
+import { QueueHandler } from './QueueHandler';
+import * as implementations from './implementations';
+
+export type QueueMessage =
+    | ({ type: 'dummy' } & implementations.DummyMessage)
+    | ({ type: 'workerBeat' } & implementations.WorkerBeatMessage);
+
+const mainQueueHandler = (message: QueueMessage, job: Job<Document>) => {
+    switch (message.type) {
+        case 'dummy':
+            return implementations.dummyHandler(message, job);
+
+        case 'workerBeat':
+            return implementations.workerBeatHandler(message, job);
+
+        default:
+            // @ts-ignore
+            throw new Error(`Message of type "${message.type}" is unknown to the worker`);
+    }
+};
+
+export const mainQueue = new QueueHandler('main', mainQueueHandler);

--- a/src/server/queues/setup.ts
+++ b/src/server/queues/setup.ts
@@ -1,12 +1,20 @@
-import { dummyQueue } from './implementations/dummyQueue';
+import { mainQueue } from './mainQueue';
 import stopAllQueues from './stopAllQueues';
 
+export const queues = [mainQueue];
+
 const setup = (): (() => Promise<void>) => {
-    // provide a periodic plan to send an email every hour
-    dummyQueue.setupWorker([
+    // setup periodic jobs on the main queue
+    mainQueue.setupWorker([
+        // provide a periodic plan to send an email every hour
         {
-            message: { value: 'periodic' },
+            message: { value: 'periodic', type: 'dummy' },
             repeat: { cron: '0 * * * *' },
+        },
+        // run a worker beat every 10s
+        {
+            message: { type: 'workerBeat' },
+            repeat: { every: 10000 },
         },
     ]);
 

--- a/src/server/queues/stopAllQueues.ts
+++ b/src/server/queues/stopAllQueues.ts
@@ -1,4 +1,4 @@
-import * as queues from './implementations';
+import { queues } from './setup';
 
 const stopAllQueues = () => Promise.all(Object.values(queues).map(queue => queue.stop()));
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -7115,6 +7115,11 @@ fill-range@^7.0.1:
   dependencies:
     to-regex-range "^5.0.1"
 
+filter-obj@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/filter-obj/-/filter-obj-1.1.0.tgz#9b311112bc6c6127a16e016c6c5d7f19e0805c5b"
+  integrity sha1-mzERErxsYSehbgFsbF1/GeCAXFs=
+
 finalhandler@~1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/finalhandler/-/finalhandler-1.1.2.tgz#b7e7d000ffd11938d0fdb053506f6ebabe9f587d"
@@ -12245,6 +12250,16 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
   integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
+query-string@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-7.1.1.tgz#754620669db978625a90f635f12617c271a088e1"
+  integrity sha512-MplouLRDHBZSG9z7fpuAAcI7aAYjDLhtsiVZsevsfaHWDS2IDdORKbSd1kWUA+V4zyva/HZoSfpwnYMMQDhb0w==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    filter-obj "^1.1.0"
+    split-on-first "^1.0.0"
+    strict-uri-encode "^2.0.0"
+
 querystring@0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/querystring/-/querystring-0.2.0.tgz#b209849203bb25df820da756e747005878521620"
@@ -13726,6 +13741,11 @@ spdx-license-ids@^3.0.0:
   resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz#50c0d8c40a14ec1bf449bae69a0ea4685a9d9f95"
   integrity sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==
 
+split-on-first@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/split-on-first/-/split-on-first-1.1.0.tgz#f610afeee3b12bce1d0c30425e76398b78249a5f"
+  integrity sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==
+
 split2@^3.0.0:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/split2/-/split2-3.2.2.tgz#bf2cf2a37d838312c249c89206fd7a17dd12365f"
@@ -13820,6 +13840,11 @@ streamsearch@0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/streamsearch/-/streamsearch-0.1.2.tgz#808b9d0e56fc273d809ba57338e929919a1a9f1a"
   integrity sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=
+
+strict-uri-encode@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-2.0.0.tgz#b9c7330c7042862f6b142dc274bbcc5866ce3546"
+  integrity sha1-ucczDHBChi9rFC3CdLvMWGbONUY=
 
 string-convert@^0.2.0:
   version "0.2.1"


### PR DESCRIPTION
Jobs are now a subtype of the main queue, however we can still create multiple queue if need be.

A worker beat has been added as a periodic job every 10s, can be use with uptime kama to provide push monitoring