### PR TITLE
feat: add API to disable 2FA on the authenticated user

### DIFF
--- a/schema/Mutation.graphql
+++ b/schema/Mutation.graphql
@@ -49,6 +49,11 @@ type Mutation {
     enableAuthenticator(token: String!, secret: String!): User!
 
     """
+    Disable 2FA / Authenticator for the signed user
+    """
+    disableAuthenticator: User!
+
+    """
     Create a web public key credential registration request
     """
     requestWebPublicKeyCredentialRegistration: WebPublicKeyCredentialRegistrationRequest!

--- a/src/app/api/index.ts
+++ b/src/app/api/index.ts
@@ -94,6 +94,8 @@ export type Mutation = {
     completeWebPublicKeyCredentialRegistration: Scalars['Boolean'];
     /** Create a new account/user */
     createAccount: User;
+    /** Disable 2FA / Authenticator for the signed user */
+    disableAuthenticator: User;
     /** Enable 2FA / Authenticator for the signed user */
     enableAuthenticator: User;
     /** Generate a challenge to authenticate with web credentials */
@@ -614,6 +616,22 @@ export type EnableAuthenticatorMutationVariables = Exact<{
 export type EnableAuthenticatorMutation = {
     __typename?: 'Mutation';
     enableAuthenticator: {
+        __typename?: 'User';
+        id: string;
+        username: string;
+        displayName: string;
+        isAuthenticatorEnabled: boolean;
+        isPasswordExpired: boolean;
+        email: string;
+        passwordExpiresAt: string | Date;
+    };
+};
+
+export type DisableAuthenticatorMutationVariables = Exact<{ [key: string]: never }>;
+
+export type DisableAuthenticatorMutation = {
+    __typename?: 'Mutation';
+    disableAuthenticator: {
         __typename?: 'User';
         id: string;
         username: string;
@@ -2345,6 +2363,83 @@ export type EnableAuthenticatorMutationResult = Apollo.MutationResult<EnableAuth
 export type EnableAuthenticatorMutationOptions = Apollo.BaseMutationOptions<
     EnableAuthenticatorMutation,
     EnableAuthenticatorMutationVariables
+>;
+export const DisableAuthenticatorDocument = /* #__PURE__ */ {
+    kind: 'Document',
+    definitions: [
+        {
+            kind: 'OperationDefinition',
+            operation: 'mutation',
+            name: { kind: 'Name', value: 'disableAuthenticator' },
+            selectionSet: {
+                kind: 'SelectionSet',
+                selections: [
+                    {
+                        kind: 'Field',
+                        name: { kind: 'Name', value: 'disableAuthenticator' },
+                        selectionSet: {
+                            kind: 'SelectionSet',
+                            selections: [{ kind: 'FragmentSpread', name: { kind: 'Name', value: 'CurrentUserData' } }],
+                        },
+                    },
+                ],
+            },
+        },
+        {
+            kind: 'FragmentDefinition',
+            name: { kind: 'Name', value: 'CurrentUserData' },
+            typeCondition: { kind: 'NamedType', name: { kind: 'Name', value: 'User' } },
+            selectionSet: {
+                kind: 'SelectionSet',
+                selections: [
+                    { kind: 'Field', name: { kind: 'Name', value: 'id' } },
+                    { kind: 'Field', name: { kind: 'Name', value: 'username' } },
+                    { kind: 'Field', name: { kind: 'Name', value: 'displayName' } },
+                    { kind: 'Field', name: { kind: 'Name', value: 'isAuthenticatorEnabled' } },
+                    { kind: 'Field', name: { kind: 'Name', value: 'isPasswordExpired' } },
+                    { kind: 'Field', name: { kind: 'Name', value: 'email' } },
+                    { kind: 'Field', name: { kind: 'Name', value: 'passwordExpiresAt' } },
+                ],
+            },
+        },
+    ],
+} as unknown as DocumentNode;
+export type DisableAuthenticatorMutationFn = Apollo.MutationFunction<
+    DisableAuthenticatorMutation,
+    DisableAuthenticatorMutationVariables
+>;
+
+/**
+ * __useDisableAuthenticatorMutation__
+ *
+ * To run a mutation, you first call `useDisableAuthenticatorMutation` within a React component and pass it any options that fit your needs.
+ * When your component renders, `useDisableAuthenticatorMutation` returns a tuple that includes:
+ * - A mutate function that you can call at any time to execute the mutation
+ * - An object with fields that represent the current status of the mutation's execution
+ *
+ * @param baseOptions options that will be passed into the mutation, supported options are listed on: https://www.apollographql.com/docs/react/api/react-hooks/#options-2;
+ *
+ * @example
+ * const [disableAuthenticatorMutation, { data, loading, error }] = useDisableAuthenticatorMutation({
+ *   variables: {
+ *   },
+ * });
+ */
+export function useDisableAuthenticatorMutation(
+    baseOptions?: Apollo.MutationHookOptions<DisableAuthenticatorMutation, DisableAuthenticatorMutationVariables>
+) {
+    const options = { ...defaultOptions, ...baseOptions };
+
+    return Apollo.useMutation<DisableAuthenticatorMutation, DisableAuthenticatorMutationVariables>(
+        DisableAuthenticatorDocument,
+        options
+    );
+}
+export type DisableAuthenticatorMutationHookResult = ReturnType<typeof useDisableAuthenticatorMutation>;
+export type DisableAuthenticatorMutationResult = Apollo.MutationResult<DisableAuthenticatorMutation>;
+export type DisableAuthenticatorMutationOptions = Apollo.BaseMutationOptions<
+    DisableAuthenticatorMutation,
+    DisableAuthenticatorMutationVariables
 >;
 export const GenerateAuthenticatorChallengeDocument = /* #__PURE__ */ {
     kind: 'Document',

--- a/src/app/api/user.graphql
+++ b/src/app/api/user.graphql
@@ -133,6 +133,12 @@ mutation enableAuthenticator($secret: String!, $token: String!) {
     }
 }
 
+mutation disableAuthenticator {
+    disableAuthenticator {
+        ...CurrentUserData
+    }
+}
+
 query generateAuthenticatorChallenge($username: String!) {
     generateAuthenticatorChallenge(username: $username) {
         token

--- a/src/app/pages/private/UserSelfPage/AuthenticatorSummary.tsx
+++ b/src/app/pages/private/UserSelfPage/AuthenticatorSummary.tsx
@@ -1,24 +1,43 @@
 import { ExclamationCircleOutlined } from '@ant-design/icons';
-import { Space, Typography, Button, notification, Modal } from 'antd';
+import { useApolloClient } from '@apollo/client';
+import { Space, Typography, Button, notification, Modal, message } from 'antd';
 import { useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
+import getApolloErrors from '../../../../server/utils/getApolloErrors';
+import * as api from '../../../api';
 
 const AuthenticatorSummary = () => {
     const { t } = useTranslation('userSelf');
+    const apolloClient = useApolloClient();
 
     const onClick = useCallback(() => {
         Modal.confirm({
             title: t('userSelf:authenticatorSettings.setup.disableConfirm.title'),
             icon: <ExclamationCircleOutlined />,
             content: t('userSelf:authenticatorSettings.setup.disableConfirm.description'),
-            onOk() {
-                notification.warning({
-                    message: t('userSelf:authenticatorSettings.setup.disabledSuccessMessage.title'),
-                    description: t('userSelf:authenticatorSettings.setup.disabledSuccessMessage.description'),
-                });
+            onOk: async () => {
+                try {
+                    await apolloClient.mutate<
+                        api.DisableAuthenticatorMutation,
+                        api.DisableAuthenticatorMutationVariables
+                    >({
+                        mutation: api.DisableAuthenticatorDocument,
+                    });
+
+                    notification.warning({
+                        message: t('userSelf:authenticatorSettings.setup.disabledSuccessMessage.title'),
+                        description: t('userSelf:authenticatorSettings.setup.disabledSuccessMessage.description'),
+                    });
+                } catch (error) {
+                    const apolloErrors = getApolloErrors(error);
+
+                    if (apolloErrors?.$root) {
+                        message.error(apolloErrors?.$root);
+                    }
+                }
             },
         });
-    }, [t]);
+    }, [t, apolloClient]);
 
     return (
         <Space direction="vertical" style={{ width: '100%' }}>

--- a/src/app/pages/private/UserSelfPage/UserSelfAuthenticatorSettings.tsx
+++ b/src/app/pages/private/UserSelfPage/UserSelfAuthenticatorSettings.tsx
@@ -1,6 +1,6 @@
 import { CheckCircleOutlined, WarningOutlined } from '@ant-design/icons';
 import { Badge, Card, Space } from 'antd';
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useAccount } from '../../../components/contexts/AccountContextManager';
 import AuthenticatorIntroduction from './AuthenticatorIntroduction';
@@ -28,6 +28,18 @@ const UserSelfAuthenticatorSettings = () => {
                 return null;
         }
     })();
+
+    useEffect(() => {
+        // handle issues where we are not back to introduction
+        if (step === 'summary' && !isAuthenticatorEnabled) {
+            setStep('introduction');
+        }
+
+        // similar, but going back to summary
+        if (step !== 'summary' && isAuthenticatorEnabled) {
+            setStep('summary');
+        }
+    }, [isAuthenticatorEnabled, step, setStep]);
 
     return (
         <Badge.Ribbon

--- a/src/server/schema/resolvers/definitions.ts
+++ b/src/server/schema/resolvers/definitions.ts
@@ -94,6 +94,8 @@ export type GraphQLMutation = {
     completeWebPublicKeyCredentialRegistration: Scalars['Boolean'];
     /** Create a new account/user */
     createAccount: GraphQLUser;
+    /** Disable 2FA / Authenticator for the signed user */
+    disableAuthenticator: GraphQLUser;
     /** Enable 2FA / Authenticator for the signed user */
     enableAuthenticator: GraphQLUser;
     /** Generate a challenge to authenticate with web credentials */
@@ -601,6 +603,7 @@ export type GraphQLMutationResolvers<
         ContextType,
         RequireFields<GraphQLMutationCreateAccountArgs, 'email' | 'password' | 'username'>
     >;
+    disableAuthenticator?: Resolver<GraphQLResolversTypes['User'], ParentType, ContextType>;
     enableAuthenticator?: Resolver<
         GraphQLResolversTypes['User'],
         ParentType,

--- a/src/server/schema/resolvers/mutations/disableAuthenticator.ts
+++ b/src/server/schema/resolvers/mutations/disableAuthenticator.ts
@@ -1,0 +1,24 @@
+import { getDatabaseContext } from '../../../database';
+import { InvalidPermission } from '../../errors';
+import { requiresLoggedUser } from '../../middlewares';
+import { GraphQLMutationResolvers } from '../definitions';
+
+const mutation: GraphQLMutationResolvers['disableAuthenticator'] = async (root, args, { getUser }) => {
+    const user = await getUser();
+
+    if (!user.otpSetup) {
+        throw new InvalidPermission();
+    }
+
+    // update the user document
+    const { collections } = await getDatabaseContext();
+    const result = await collections.users.findOneAndUpdate(
+        { _id: user._id },
+        { $set: { otpSetup: null } },
+        { returnDocument: 'after' }
+    );
+
+    return result.value;
+};
+
+export default requiresLoggedUser(mutation);

--- a/src/server/schema/resolvers/mutations/index.ts
+++ b/src/server/schema/resolvers/mutations/index.ts
@@ -11,3 +11,4 @@ export { default as completeWebPublicKeyCredentialRegistration } from './complet
 export { default as revokeWebPublicKeyCredential } from './revokeWebPublicKeyCredential';
 export { default as revokeUserSession } from './revokeUserSession';
 export { default as authenticateWithWebPublicKeyCredential } from './authenticateWithWebPublicKeyCredential';
+export { default as disableAuthenticator } from './disableAuthenticator';

--- a/src/server/schema/typeDefs.graphql
+++ b/src/server/schema/typeDefs.graphql
@@ -110,6 +110,10 @@ type Mutation {
     """
     createAccount(email: String!, password: String!, username: String!): User!
     """
+    Disable 2FA / Authenticator for the signed user
+    """
+    disableAuthenticator: User!
+    """
     Enable 2FA / Authenticator for the signed user
     """
     enableAuthenticator(secret: String!, token: String!): User!


### PR DESCRIPTION
We couldn't remove 2FA once setup on a user as the API to do so was missing. Therefore `disableAuthenticator` was added to the API and implemented on the components upon user actions to revoke the 2FA.

While solving this issue, I found out there was some issues with refresh as Apollo state was not refreshed on the same tick as the React state inside the components for this function on the user profile. To solve this situation, `useEffect` has been added to automatically correct the step component to display.